### PR TITLE
Travis: build and run macros-examples.

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -62,6 +62,9 @@ EOF
      ./configure --bindir=$PREFIX/bin --libdir=$PREFIX/lib/ocaml \
        --pkgdir=$PREFIX/lib/ocaml && \
       make && make install)
+    git clone -b master https://github.com/OlivierNicole/macros-examples
+    (cd macros-examples &&
+      make && make test)
     # git clone git://github.com/ocaml/opam
     # (cd opam && ./configure --prefix $PREFIX &&\
     #   make lib-ext && make && make install)


### PR DESCRIPTION
This updates the Travis script to build and run the [macros-examples](https://github.com/yallop/macros-examples) repository.

It depends on OlivierNicole/macros-examples#1 and OlivierNicole/macros-examples#2 being merged.

It also depends on Travis being set up to run on each commit to this repository, which can be done here: https://travis-ci.org/OlivierNicole/ocaml.